### PR TITLE
a bare bones gem to pull migrations into a rails app

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,3 @@
 source 'https://rubygems.org'
 
-gem 'sinatra_auth_github'
-gem 'thin'
-gem "activerecord"
-gem "sinatra-activerecord"
-gem "pg"
-gem "rake"
+gemspec

--- a/lib/ppwm-matcher.rb
+++ b/lib/ppwm-matcher.rb
@@ -1,0 +1,1 @@
+require 'ppwm-matcher/engine'

--- a/lib/ppwm-matcher/engine.rb
+++ b/lib/ppwm-matcher/engine.rb
@@ -1,0 +1,5 @@
+module PpwmMatcher
+  class Engine < ::Rails::Engine
+    engine_name "ppwm-matcher"
+  end
+end

--- a/ppwm-matcher.gemspec
+++ b/ppwm-matcher.gemspec
@@ -1,18 +1,19 @@
 Gem::Specification.new do |s|
-  s.name        = "ppwm-matcher"
-  s.version     = "0.0.1"
+  s.name        = 'ppwm-matcher'
+  s.version     = '0.0.1'
   s.authors     = ['Avdi Grimm']
-  s.email       = [""]
-  s.homepage    = "https://github.com/rubyrogues/ppwm-matcher"
-  s.summary     = ""
-  s.description = ""
+  s.email       = ['']
+  s.homepage    = 'https://github.com/rubyrogues/ppwm-matcher'
+  s.summary     = ''
+  s.description = ''
 
-  s.files = Dir["{config,db,lib,models,public}/**/*"]
+  s.files = Dir['{config,db,lib,models,public}/**/*']
 
   s.add_dependency 'sinatra_auth_github'
-  s.add_dependency 'thin'
-  s.add_dependency "activerecord"
-  s.add_dependency "sinatra-activerecord"
-  s.add_dependency "pg"
-  s.add_dependency "rake"
+  s.add_dependency 'activerecord'
+  s.add_dependency 'sinatra-activerecord'
+  s.add_dependency 'pg'
+  s.add_dependency 'rake'
+
+  s.add_development_dependency 'thin'
 end

--- a/ppwm-matcher.gemspec
+++ b/ppwm-matcher.gemspec
@@ -1,0 +1,18 @@
+Gem::Specification.new do |s|
+  s.name        = "ppwm-matcher"
+  s.version     = "0.0.1"
+  s.authors     = ['Avdi Grimm']
+  s.email       = [""]
+  s.homepage    = "https://github.com/rubyrogues/ppwm-matcher"
+  s.summary     = ""
+  s.description = ""
+
+  s.files = Dir["{config,db,lib,models,public}/**/*"]
+
+  s.add_dependency 'sinatra_auth_github'
+  s.add_dependency 'thin'
+  s.add_dependency "activerecord"
+  s.add_dependency "sinatra-activerecord"
+  s.add_dependency "pg"
+  s.add_dependency "rake"
+end


### PR DESCRIPTION
This has just enough changes to expose `rake ppwm-matcher:install:migrations` I'm sure there is a lot more that needs to be done to get thee rest working in the Rails app it's used in.

I can probably help with that as well if needed.
