### PR TITLE
Add before block to pre-authenticate with GH, close #12

### DIFF
--- a/lib/ppwm_matcher/app.rb
+++ b/lib/ppwm_matcher/app.rb
@@ -15,6 +15,14 @@ module PpwmMatcher
 
     register Sinatra::Auth::Github
 
+    # actions that don't require GH auth
+    open_actions = %w(unauthenticated code/import)
+
+    before '/*' do
+      return if open_actions.include? params[:splat].first
+      authenticate!
+    end
+
     helpers do
       def repos
         github_request("user/repos")
@@ -22,8 +30,6 @@ module PpwmMatcher
     end
 
     get '/' do
-      authenticate!
-
       @message = ''
       @email = github_user.email
       @login = github_user.login
@@ -50,8 +56,6 @@ module PpwmMatcher
     end
 
     post '/code' do
-      authenticate!
-
       # Store the user, check code
       user = User.where(:email => params['email']).first_or_create
       code = Code.where(:value => params['code']).first


### PR DESCRIPTION
Add before block that calls `authenticate!` before every action, to ensure that the user is authenticated with Github.

Actions can be excluded by putting them in the `open_actions` array. Currently, _/unauthenticated_ and _/code/import_ are in there.

Could someone review and test?

Thanks
