### PR TITLE
Email users on successful pairing

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,6 +4,7 @@ PATH
     ppwm-matcher (0.0.1)
       activerecord
       pg
+      pony
       rake
       sinatra-activerecord
       sinatra_auth_github
@@ -52,6 +53,8 @@ GEM
     guard-rspec (3.0.2)
       guard (>= 1.8)
       rspec (~> 2.13)
+    haml (4.0.3)
+      tilt
     hashie (2.0.5)
     i18n (0.6.1)
     listen (1.2.1)
@@ -59,7 +62,20 @@ GEM
       rb-inotify (>= 0.9)
       rb-kqueue (>= 0.2)
     lumberjack (1.0.3)
+    mail (2.5.4)
+      mime-types (~> 1.16)
+      treetop (~> 1.4.8)
+    mailcatcher (0.5.12)
+      activesupport (~> 3.0)
+      eventmachine (~> 1.0.0)
+      haml (>= 3.1, < 5)
+      mail (~> 2.3)
+      sinatra (~> 1.2)
+      skinny (~> 0.2.3)
+      sqlite3 (~> 1.3)
+      thin (~> 1.5.0)
     method_source (0.8.1)
+    mime-types (1.23)
     multi_json (1.7.5)
     multipart-post (1.2.0)
     netrc (0.7.7)
@@ -71,6 +87,9 @@ GEM
       multi_json (~> 1.3)
       netrc (~> 0.7.7)
     pg (0.15.1)
+    polyglot (0.3.3)
+    pony (1.4.1)
+      mail (> 2.0)
     pry (0.9.12.2)
       coderay (~> 1.0.5)
       method_source (~> 0.8)
@@ -94,16 +113,19 @@ GEM
     rspec-expectations (2.13.0)
       diff-lcs (>= 1.1.3, < 2.0)
     rspec-mocks (2.13.1)
-    sinatra (1.3.6)
+    sinatra (1.4.3)
       rack (~> 1.4)
-      rack-protection (~> 1.3)
-      tilt (~> 1.3, >= 1.3.3)
+      rack-protection (~> 1.4)
+      tilt (~> 1.3, >= 1.3.4)
     sinatra-activerecord (1.2.2)
       activerecord (~> 3.0)
       sinatra (~> 1.0)
     sinatra_auth_github (0.13.3)
       sinatra (~> 1.0)
       warden-github (~> 0.13.1)
+    skinny (0.2.3)
+      eventmachine (~> 1.0.0)
+      thin (~> 1.5.0)
     slop (3.4.5)
     sqlite3 (1.3.7)
     thin (1.5.0)
@@ -112,6 +134,9 @@ GEM
       rack (>= 1.0.0)
     thor (0.18.1)
     tilt (1.4.1)
+    treetop (1.4.14)
+      polyglot
+      polyglot (>= 0.3.1)
     tzinfo (0.3.37)
     warden (1.2.1)
       rack (>= 1.0)
@@ -129,6 +154,7 @@ DEPENDENCIES
   guard
   guard-bundler
   guard-rspec
+  mailcatcher
   ppwm-matcher!
   rack-test
   rspec

--- a/lib/ppwm_matcher/app.rb
+++ b/lib/ppwm_matcher/app.rb
@@ -114,6 +114,12 @@ module PpwmMatcher
         code: params['code']
       })
 
+      if matcher.code
+        # Send mails if both pairs have signed in
+        mailer = UserMailer.new(Pony)
+        matcher.code.add_observer(mailer)
+      end
+
       if matcher.valid? && matcher.assign_code_to_user
         @pair = matcher.user.pair
         @code_value = matcher.code.value

--- a/lib/ppwm_matcher/app.rb
+++ b/lib/ppwm_matcher/app.rb
@@ -14,9 +14,36 @@ module PpwmMatcher
 
     set :github_options, PpwmMatcher::GithubAuth.options.merge(:failure_app => self)
 
-    configure do
+    http_defaults = -> do
       set :admin_username, ENV.fetch('ADMIN_USERNAME') { 'admin' }
       set :admin_password, ENV.fetch('ADMIN_PASSWORD') { 'ZOMGSECRET' }
+    end
+
+    configure :test, :development do
+      http_defaults.call
+      Pony.options = {
+        :via => :smtp,
+        :via_options => {
+          :address => 'localhost',
+          :port => '1025'
+        }
+      }
+    end
+
+    configure :production do
+      http_defaults.call
+      Pony.options = {
+        :via => :smtp,
+        :via_options => {
+          :address => 'smtp.sendgrid.net',
+          :port => '587',
+          :domain => 'heroku.com',
+          :user_name => ENV['SENDGRID_USERNAME'],
+          :password => ENV['SENDGRID_PASSWORD'],
+          :authentication => :plain,
+          :enable_starttls_auto => true
+        }
+      }
     end
 
     register Sinatra::Auth::Github

--- a/lib/ppwm_matcher/app.rb
+++ b/lib/ppwm_matcher/app.rb
@@ -1,6 +1,7 @@
 require 'logger'
 require 'sinatra'
 require 'sinatra_auth_github'
+require 'pony'
 require 'ppwm_matcher/models/code'
 require 'ppwm_matcher/models/user'
 require 'ppwm_matcher/models/code_matcher'

--- a/lib/ppwm_matcher/app.rb
+++ b/lib/ppwm_matcher/app.rb
@@ -6,6 +6,7 @@ require 'ppwm_matcher/models/code'
 require 'ppwm_matcher/models/user'
 require 'ppwm_matcher/models/code_matcher'
 require 'ppwm_matcher/models/github_auth'
+require 'ppwm_matcher/observers/user_mailer'
 
 module PpwmMatcher
   class App < Sinatra::Base

--- a/lib/ppwm_matcher/observers/user_mailer.rb
+++ b/lib/ppwm_matcher/observers/user_mailer.rb
@@ -23,7 +23,7 @@ module PpwmMatcher
       return <<-EOD
 Hi #{user.github_login},
 
-You've been paired up with #{paired_user.github_login}! You can email him at #{paired_user.email}.
+You've been paired up with #{paired_user.github_login}! You can email them at #{paired_user.email}.
 
 Happy hacking!
 

--- a/lib/ppwm_matcher/observers/user_mailer.rb
+++ b/lib/ppwm_matcher/observers/user_mailer.rb
@@ -6,10 +6,30 @@ module PpwmMatcher
 
     def users_assigned(users)
       if users.length == 2
-        users.each do |user|
-          @client.mail(:to => user.email, :subject => "You've been paired up with #{user.github_login}!")
+        users.permutation.each do |user, paired_user|
+          @client.mail(mail_options(user, paired_user))
         end
       end
+    end
+
+    private
+    def mail_options(user, paired_user)
+      { :to      => user.email,
+        :subject => "You've been paired up with #{user.github_login}!",
+        :body    => mail_body(user, paired_user) }
+    end
+
+    def mail_body(user, paired_user)
+      return <<-EOD
+Hi #{user.github_login},
+
+You've been paired up with #{paired_user.github_login}! You can email him at #{paired_user.email}.
+
+Happy hacking!
+
+--
+Sent by http://pairprogramwith.me
+      EOD
     end
   end
 end

--- a/lib/ppwm_matcher/observers/user_mailer.rb
+++ b/lib/ppwm_matcher/observers/user_mailer.rb
@@ -15,7 +15,7 @@ module PpwmMatcher
     private
     def mail_options(user, paired_user)
       { :to      => user.email,
-        :subject => "You've been paired up with #{user.github_login}!",
+        :subject => "You've been paired up with #{paired_user.github_login}!",
         :body    => mail_body(user, paired_user) }
     end
 

--- a/lib/ppwm_matcher/observers/user_mailer.rb
+++ b/lib/ppwm_matcher/observers/user_mailer.rb
@@ -1,0 +1,15 @@
+module PpwmMatcher
+  class UserMailer
+    def initialize(mail_client)
+      @client = mail_client
+    end
+
+    def users_assigned(users)
+      if users.length == 2
+        users.each do |user|
+          @client.mail(:to => user.email, :subject => "You've been paired up with #{user.github_login}!")
+        end
+      end
+    end
+  end
+end

--- a/ppwm-matcher.gemspec
+++ b/ppwm-matcher.gemspec
@@ -14,6 +14,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'sinatra-activerecord'
   s.add_dependency 'pg'
   s.add_dependency 'rake'
+  s.add_dependency 'pony'
 
   s.add_development_dependency 'thin'
   s.add_development_dependency 'rspec'
@@ -22,6 +23,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'sqlite3'
   s.add_development_dependency 'rack-test'
   s.add_development_dependency 'database_cleaner'
+  s.add_development_dependency 'mailcatcher'
 
   s.add_development_dependency 'guard'
   s.add_development_dependency 'guard-bundler'

--- a/spec/models/code_spec.rb
+++ b/spec/models/code_spec.rb
@@ -62,4 +62,25 @@ describe PpwmMatcher::Code do
       expect { code.assign_user(user) }.to change{ code.users(true).count }
     end
   end
+
+  context "after adding an observer" do
+    let(:code)     { PpwmMatcher::Code.new }
+    let(:observer) { double("observer", :users_assigned => true) }
+    before         { code.add_observer(observer) }
+    subject        { code.observers }
+
+    its(:length) { should == 1 }
+
+    context "calling #assign_user" do
+      let(:user1) { FactoryGirl.build(:user) }
+      let(:user2) { FactoryGirl.build(:user) }
+      before      { code.users << user1 }
+
+      it "should notify the observer" do
+        observer.should_receive(:users_assigned).with([user1, user2])
+        code.assign_user(user2)
+      end
+    end
+  end
+
 end

--- a/spec/observers/user_mailer_observer_spec.rb
+++ b/spec/observers/user_mailer_observer_spec.rb
@@ -1,0 +1,31 @@
+module PpwmMatcher
+  describe UserMailer do
+    let(:mail_client) { double("Pony", mail: true) }  # Double Pony? Hehe.
+    let(:observer)    { UserMailer.new(mail_client) }
+
+    context "when given no users" do
+      it "expects no mail to be sent" do
+        mail_client.should_not_receive(:mail)
+        observer.users_assigned([])
+      end
+    end
+
+    context "when given a single user" do
+      it "expects no mail to be sent" do
+        mail_client.should_not_receive(:mail)
+        observer.users_assigned([double("User")])
+      end
+    end
+
+    context "when given two users" do
+      let(:user1) { double("User", email: 'tim@example.com', github_login: 'timmy') }
+      let(:user2) { double("User", email: 'bob@example.com', github_login: 'bobby') }
+
+      it "expects mail to be sent" do
+        mail_client.should_receive(:mail).with(to: user1.email, subject: "You've been paired up with timmy!")
+        mail_client.should_receive(:mail).with(to: user2.email, subject: "You've been paired up with bobby!")
+        observer.users_assigned([user1, user2])
+      end
+    end
+  end
+end

--- a/spec/observers/user_mailer_spec.rb
+++ b/spec/observers/user_mailer_spec.rb
@@ -25,12 +25,12 @@ module PpwmMatcher
         mail_client.should_receive(:mail) do |opts|
           opts[:to].should == user1.email
           opts[:subject].should == "You've been paired up with bobby!"
-          opts[:body].should include("You can email him at bob@example.com")
+          opts[:body].should include("You can email them at bob@example.com")
         end
         mail_client.should_receive(:mail) do |opts|
           opts[:to].should == user2.email
           opts[:subject].should == "You've been paired up with timmy!"
-          opts[:body].should include("You can email him at tim@example.com")
+          opts[:body].should include("You can email them at tim@example.com")
         end
         mailer.users_assigned([user1, user2])
       end

--- a/spec/observers/user_mailer_spec.rb
+++ b/spec/observers/user_mailer_spec.rb
@@ -1,19 +1,19 @@
 module PpwmMatcher
   describe UserMailer do
     let(:mail_client) { double("Pony", mail: true) }  # Double Pony? Hehe.
-    let(:observer)    { UserMailer.new(mail_client) }
+    let(:mailer)    { UserMailer.new(mail_client) }
 
     context "when given no users" do
       it "expects no mail to be sent" do
         mail_client.should_not_receive(:mail)
-        observer.users_assigned([])
+        mailer.users_assigned([])
       end
     end
 
     context "when given a single user" do
       it "expects no mail to be sent" do
         mail_client.should_not_receive(:mail)
-        observer.users_assigned([double("User")])
+        mailer.users_assigned([ double("User") ])
       end
     end
 
@@ -22,9 +22,17 @@ module PpwmMatcher
       let(:user2) { double("User", email: 'bob@example.com', github_login: 'bobby') }
 
       it "expects mail to be sent" do
-        mail_client.should_receive(:mail).with(to: user1.email, subject: "You've been paired up with timmy!")
-        mail_client.should_receive(:mail).with(to: user2.email, subject: "You've been paired up with bobby!")
-        observer.users_assigned([user1, user2])
+        mail_client.should_receive(:mail) do |opts|
+          opts[:to] == user1.email &&
+          opts[:subject] == "You've been paired up with bobby!" &&
+          opts[:body].include?("You can email him at bob@example.com")
+        end
+        mail_client.should_receive(:mail) do |opts|
+          opts[:to] == user2.email &&
+          opts[:subject] == "You've been paired up with timmy!" &&
+          opts[:body].include?("You can email him at tim@example.com")
+        end
+        mailer.users_assigned([user1, user2])
       end
     end
   end

--- a/spec/observers/user_mailer_spec.rb
+++ b/spec/observers/user_mailer_spec.rb
@@ -23,14 +23,14 @@ module PpwmMatcher
 
       it "expects mail to be sent" do
         mail_client.should_receive(:mail) do |opts|
-          opts[:to] == user1.email &&
-          opts[:subject] == "You've been paired up with bobby!" &&
-          opts[:body].include?("You can email him at bob@example.com")
+          opts[:to].should == user1.email
+          opts[:subject].should == "You've been paired up with bobby!"
+          opts[:body].should include("You can email him at bob@example.com")
         end
         mail_client.should_receive(:mail) do |opts|
-          opts[:to] == user2.email &&
-          opts[:subject] == "You've been paired up with timmy!" &&
-          opts[:body].include?("You can email him at tim@example.com")
+          opts[:to].should == user2.email
+          opts[:subject].should == "You've been paired up with timmy!"
+          opts[:body].should include("You can email him at tim@example.com")
         end
         mailer.users_assigned([user1, user2])
       end


### PR DESCRIPTION
I'm not suggesting this is complete - best to look and talk it through before merging! Here's what it does:
- When the first user submits their code, they get no email
- When their mystery pair submits their code, an email (currently identical with names/emails swapped) is sent to each user
- The email gives the github username and email address of their pair
- It only sends these emails once

I've used an observer pattern to keep the mail stuff out of the way. It's using Pony, and I've added mailcatcher as a development dependency (because it's ace, apart from having a dependency on haml). There's a separate configuration for development/test and production environments, since production is going to use sendmail on heroku.

The email body can definitely be changed, I just put down what came to mind.

Thanks @rjackson for the suggestions of tools and things.
