### PR TITLE
Add User#name, and use in UserMailer.

### DIFF
--- a/db/migrate/20130614151140_add_name_to_users.rb
+++ b/db/migrate/20130614151140_add_name_to_users.rb
@@ -1,0 +1,9 @@
+class AddNameToUsers < ActiveRecord::Migration
+  def up
+    add_column :ppwm_matcher_users, :name, :string
+  end
+
+  def down
+    remove_column :ppwm_matcher_users, :name
+  end
+end

--- a/lib/ppwm_matcher/models/user.rb
+++ b/lib/ppwm_matcher/models/user.rb
@@ -2,7 +2,8 @@ module PpwmMatcher
   class User < ActiveRecord::Base
     self.table_name_prefix = "ppwm_matcher_"
 
-    attr_accessible :email, :code_id
+    attr_accessible :email, :code_id, :name, :gravatar_id
+
     belongs_to :code, validate: true
     validates :email, presence: true
 
@@ -27,7 +28,8 @@ module PpwmMatcher
     def self.update_or_create(email, github_user)
       user = where(:github_login => github_user.login).first_or_initialize(
         :gravatar_id   => github_user.gravatar_id,
-        :github_login  => github_user.login
+        :github_login  => github_user.login,
+        :name          => github_user.name
       )
       user.email = email
       user.save

--- a/lib/ppwm_matcher/observers/user_mailer.rb
+++ b/lib/ppwm_matcher/observers/user_mailer.rb
@@ -21,9 +21,9 @@ module PpwmMatcher
 
     def mail_body(user, paired_user)
       return <<-EOD
-Hi #{user.github_login},
+Hi #{user.name},
 
-You've been paired up with #{paired_user.github_login}! You can email them at #{paired_user.email}.
+You've been paired up with #{paired_user.name} (gh: #{paired_user.github_login})! You can email them at #{paired_user.email}.
 
 Happy hacking!
 

--- a/lib/ppwm_matcher/observers/user_mailer.rb
+++ b/lib/ppwm_matcher/observers/user_mailer.rb
@@ -16,6 +16,7 @@ module PpwmMatcher
     def mail_options(user, paired_user)
       { :from    => 'matcher@pairprogramwith.me',
         :to      => user.email,
+        :reply_to => paired_user.email,
         :subject => "You've been paired up with #{paired_user.github_login}!",
         :body    => mail_body(user, paired_user) }
     end
@@ -24,7 +25,7 @@ module PpwmMatcher
       return <<-EOD
 Hi #{user.name},
 
-You've been paired up with #{paired_user.name} (gh: #{paired_user.github_login})! You can email them at #{paired_user.email}.
+You've been paired up with #{paired_user.name} (gh: #{paired_user.github_login})! You can email them at #{paired_user.email} (or just reply to this email).
 
 Happy hacking!
 

--- a/lib/ppwm_matcher/observers/user_mailer.rb
+++ b/lib/ppwm_matcher/observers/user_mailer.rb
@@ -14,7 +14,8 @@ module PpwmMatcher
 
     private
     def mail_options(user, paired_user)
-      { :to      => user.email,
+      { :from    => 'matcher@pairprogramwith.me',
+        :to      => user.email,
         :subject => "You've been paired up with #{paired_user.github_login}!",
         :body    => mail_body(user, paired_user) }
     end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -22,5 +22,6 @@ FactoryGirl.define do
 
   factory :user, :class => PpwmMatcher::User do
     email { Faker::Internet.email }
+    name  { Faker::Name.name }
   end
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -21,7 +21,9 @@ FactoryGirl.define do
   end
 
   factory :user, :class => PpwmMatcher::User do
-    email { Faker::Internet.email }
-    name  { Faker::Name.name }
+    email        { Faker::Internet.email }
+    name         { Faker::Name.name }
+    gravatar_id  { rand(1..5000) }
+    github_login { Faker::Internet.user_name }
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -40,4 +40,49 @@ describe PpwmMatcher::User do
       expect(user.pair).to      eql(pair_user)
     end
   end
+
+  describe ".update_or_create" do
+    let(:github_user) do
+      double("github_user", :gravatar_id => rand(1..5000),
+                            :login       => Faker::Internet.user_name,
+                            :name        => Faker::Name.name,
+                            :email       => Faker::Internet.email
+            )
+    end
+
+    describe "when a user already exists" do
+      let!(:user) { FactoryGirl.create(:user, :github_login => github_user.login) }
+
+      it "finds and returns an existing user" do
+        expect(
+          described_class.update_or_create(user.email, github_user)
+        ).to eql(user)
+      end
+
+      it "sets the users email to the provided value" do
+        new_email = Faker::Internet.email
+
+        user = described_class.update_or_create(new_email, github_user)
+
+        expect(user.email).to eql(new_email)
+      end
+    end
+
+    describe "when no user exists" do
+      it "creates the user with the provided information" do
+        user = described_class.update_or_create(github_user.email, github_user)
+
+        expect(user.email).to         eql(github_user.email)
+        expect(user.gravatar_id).to   eql(github_user.gravatar_id)
+        expect(user.name).to          eql(github_user.name)
+        expect(user.github_login).to  eql(github_user.login)
+      end
+
+      it "should returned a saved user" do
+        user = described_class.update_or_create(github_user.email, github_user)
+
+        expect(user).not_to be_changed
+      end
+    end
+  end
 end

--- a/spec/observers/user_mailer_spec.rb
+++ b/spec/observers/user_mailer_spec.rb
@@ -18,21 +18,25 @@ module PpwmMatcher
     end
 
     context "when given two users" do
-      let(:user1) { double("User", email: 'tim@example.com', github_login: 'timmy') }
-      let(:user2) { double("User", email: 'bob@example.com', github_login: 'bobby') }
+      let(:users) do
+        [ double("User", name: 'Tim Bower', email: 'tim@example.com', github_login: 'timmy') ,
+          double("User", name: 'Bob Timberland', email: 'bob@example.com', github_login: 'bobby') ]
+      end
 
       it "expects mail to be sent" do
-        mail_client.should_receive(:mail) do |opts|
-          opts[:to].should == user1.email
-          opts[:subject].should == "You've been paired up with bobby!"
-          opts[:body].should include("You can email them at bob@example.com")
+        users.permutation.each do |user, pair|
+          mail_client.should_receive(:mail) do |opts|
+            opts[:from].should == 'matcher@pairprogramwith.me'
+            opts[:reply_to].should == pair.email
+            opts[:to].should == user.email
+            opts[:subject].should == "You've been paired up with #{pair.github_login}!"
+            opts[:body].should include("Hi #{user.name},")
+            opts[:body].should include("You can email them at #{pair.email}")
+            opts[:body].should include("You've been paired up with #{pair.name}")
+          end
         end
-        mail_client.should_receive(:mail) do |opts|
-          opts[:to].should == user2.email
-          opts[:subject].should == "You've been paired up with timmy!"
-          opts[:body].should include("You can email them at tim@example.com")
-        end
-        mailer.users_assigned([user1, user2])
+
+        mailer.users_assigned(users)
       end
     end
   end


### PR DESCRIPTION
- Add User#name to database
- Setup from address on UserMailer
- Add reply_to functionality to UserMailer
- Reword generated email to use name
