### PR TITLE
Properly handle User#name being nil.

### DIFF
--- a/lib/ppwm_matcher/models/user.rb
+++ b/lib/ppwm_matcher/models/user.rb
@@ -26,13 +26,12 @@ module PpwmMatcher
     end
 
     def self.update_or_create(email, github_user)
-      user = where(:github_login => github_user.login).first_or_initialize(
-        :gravatar_id   => github_user.gravatar_id,
-        :github_login  => github_user.login,
-        :name          => github_user.name
-      )
-      user.email = email
-      user.save
+      user = where(:github_login => github_user.login).first_or_initialize
+
+      user.update_attributes(:gravatar_id   => github_user.gravatar_id,
+                             :name          => github_user.name,
+                             :email         => email)
+
       user
     end
   end

--- a/lib/ppwm_matcher/observers/user_mailer.rb
+++ b/lib/ppwm_matcher/observers/user_mailer.rb
@@ -23,15 +23,23 @@ module PpwmMatcher
 
     def mail_body(user, paired_user)
       return <<-EOD
-Hi #{user.name},
+Hi #{user.name || user.github_login},
 
-You've been paired up with #{paired_user.name} (gh: #{paired_user.github_login})! You can email them at #{paired_user.email} (or just reply to this email).
+You've been paired up with #{pair_name_for paired_user}! You can email them at #{paired_user.email} (or just reply to this email).
 
 Happy hacking!
 
 --
 Sent by http://pairprogramwith.me
       EOD
+    end
+
+    def pair_name_for(paired_user)
+      if paired_user.name
+        "#{paired_user.name} (gh: #{paired_user.github_login})"
+      else
+        "#{paired_user.github_login}"
+      end
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -66,6 +66,22 @@ describe PpwmMatcher::User do
 
         expect(user.email).to eql(new_email)
       end
+
+      it "sets the name to the provided value" do
+        expect(user.name).not_to eql(github_user.name)
+
+        user = described_class.update_or_create(github_user.email, github_user)
+
+        expect(user.name).to eql(github_user.name)
+      end
+
+      it "sets the gravatar_id to the provided value" do
+        expect(user.gravatar_id).not_to eql(github_user.gravatar_id)
+
+        user = described_class.update_or_create(github_user.email, github_user)
+
+        expect(user.gravatar_id).to eql(github_user.gravatar_id)
+      end
     end
 
     describe "when no user exists" do

--- a/spec/observers/user_mailer_spec.rb
+++ b/spec/observers/user_mailer_spec.rb
@@ -18,12 +18,10 @@ module PpwmMatcher
     end
 
     context "when given two users" do
-      let(:users) do
-        [ double("User", name: 'Tim Bower', email: 'tim@example.com', github_login: 'timmy') ,
-          double("User", name: 'Bob Timberland', email: 'bob@example.com', github_login: 'bobby') ]
-      end
-
       it "expects mail to be sent" do
+        users = [ double("User", name: 'Tim Bower', email: 'tim@example.com', github_login: 'timmy') ,
+                  double("User", name: 'Bob Timberland', email: 'bob@example.com', github_login: 'bobby') ]
+
         users.permutation.each do |user, pair|
           mail_client.should_receive(:mail) do |opts|
             opts[:from].should == 'matcher@pairprogramwith.me'
@@ -33,6 +31,20 @@ module PpwmMatcher
             opts[:body].should include("Hi #{user.name},")
             opts[:body].should include("You can email them at #{pair.email}")
             opts[:body].should include("You've been paired up with #{pair.name}")
+          end
+        end
+
+        mailer.users_assigned(users)
+      end
+
+      it "uses github_login if name isn't present" do
+        users = [ double("User", name: nil, email: 'tim@example.com', github_login: 'timmy') ,
+                  double("User", name: nil, email: 'bob@example.com', github_login: 'bobby') ]
+
+        users.permutation.each do |user, pair|
+          mail_client.should_receive(:mail) do |opts|
+            opts[:body].should include("Hi #{user.github_login},")
+            opts[:body].should include("You've been paired up with #{pair.github_login}")
           end
         end
 


### PR DESCRIPTION
Fallback to using User#github_login if name isn't present.
