### PR TITLE
WIP:  Add user profile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
 source 'https://rubygems.org'
 
 gemspec
+
+gem 'thin'

--- a/Rakefile
+++ b/Rakefile
@@ -1,11 +1,15 @@
 require './app'
 require 'sinatra/activerecord/rake'
 
-require 'rspec/core/rake_task'
+begin
+  require 'rspec/core/rake_task'
 
-RSpec::Core::RakeTask.new(:spec)
+  RSpec::Core::RakeTask.new(:spec)
 
-task :default => :spec
+  task :default => :spec
+rescue LoadError
+  puts "We don't have rspec"
+end
 
 namespace :db do
   desc "Populate the database with example data"

--- a/lib/ppwm_matcher/app.rb
+++ b/lib/ppwm_matcher/app.rb
@@ -98,6 +98,16 @@ module PpwmMatcher
       end
     end
 
+    get '/profile/:github_login' do
+      # TODO revisit how to ensure we get a safe string
+      github_login = params[:github_login].to_s.gsub(/[\s-\/\\\.]/, '')
+      user = User.current(github_login)
+      if user
+        "Hello #{github_login}"
+      else
+        "No such user"
+      end
+    end
     get '/code' do
       user = User.current(github_user.login) # TODO: refactor to helper method ?
       redirect '/' unless user && user.code

--- a/lib/ppwm_matcher/app.rb
+++ b/lib/ppwm_matcher/app.rb
@@ -101,9 +101,9 @@ module PpwmMatcher
     get '/profile/:github_login' do
       # TODO revisit how to ensure we get a safe string
       github_login = params[:github_login].to_s.gsub(/[\s\-\/\\\.]/, '')
-      user = User.current(github_login)
-      if user
-        "Hello #{github_login}"
+      @user = User.current(github_login)
+      if @user
+        erb :profile, layout: :layout
       else
         "No such user"
       end

--- a/lib/ppwm_matcher/app.rb
+++ b/lib/ppwm_matcher/app.rb
@@ -100,7 +100,7 @@ module PpwmMatcher
 
     get '/profile/:github_login' do
       # TODO revisit how to ensure we get a safe string
-      github_login = params[:github_login].to_s.gsub(/[\s-\/\\\.]/, '')
+      github_login = params[:github_login].to_s.gsub(/[\s\-\/\\\.]/, '')
       user = User.current(github_login)
       if user
         "Hello #{github_login}"

--- a/lib/ppwm_matcher/app.rb
+++ b/lib/ppwm_matcher/app.rb
@@ -99,7 +99,7 @@ module PpwmMatcher
     end
 
     get '/code' do
-      user = User.current(github_user) # TODO: refactor to helper method ?
+      user = User.current(github_user.login) # TODO: refactor to helper method ?
       redirect '/' unless user && user.code
 
       @pair = user.pair
@@ -136,7 +136,7 @@ module PpwmMatcher
       @email = params['email'] || github_user.email
       @name = github_user.name || github_user.login
 
-      user = User.current(github_user)
+      user = User.current(github_user.login)
       if user && user.has_code?
         @has_code = true
       end

--- a/lib/ppwm_matcher/models/user.rb
+++ b/lib/ppwm_matcher/models/user.rb
@@ -21,8 +21,8 @@ module PpwmMatcher
       User.where(:code_id => self.code_id).detect{|u| u != self }
     end
 
-    def self.current(github_user)
-      where(:github_login => github_user.login).limit(1).first
+    def self.current(github_login)
+      where(:github_login => github_login).limit(1).first
     end
 
     def self.update_or_create(email, github_user)

--- a/lib/ppwm_matcher/views/profile.erb
+++ b/lib/ppwm_matcher/views/profile.erb
@@ -1,0 +1,7 @@
+<%= @user.name %>'s Profile
+<br>
+<ul>
+  <li>Email : <%= @user.email %></li>
+  <li>Github user : <%= @user.github_login %></li>
+  <li><img src="https://secure.gravatar.com/avatar/<%= @user.gravatar_id %>" alt="Gravatar" style="margin-right: 18px" /></li>
+</ul>

--- a/ppwm-matcher.gemspec
+++ b/ppwm-matcher.gemspec
@@ -16,7 +16,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'rake'
   s.add_dependency 'pony'
 
-  s.add_development_dependency 'thin'
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'faker'
   s.add_development_dependency 'factory_girl'

--- a/spec/app_spec.rb
+++ b/spec/app_spec.rb
@@ -27,6 +27,26 @@ describe PpwmMatcher::App do
     end
   end
 
+  describe "GET /profile/:github_login" do
+    context 'the user is authorized' do
+      it 'if the user exists, says Hello github_login' do
+        login_as github_user
+
+        PpwmMatcher::User.update_or_create('foo@example.com', github_user)
+        get "/profile/#{github_user.login}"
+
+        expect(last_response.body).to include("Hello #{github_user.login}")
+      end
+      it 'if user does not exists,says No such user' do
+        login_as github_user
+
+        get "/profile/#{github_user.login}"
+
+        expect(last_response.body).to include('No such user')
+      end
+    end
+  end
+
   describe "GET /unauthenticated" do
     it "should not redirect for authentication" do
       get '/unauthenticated'

--- a/spec/app_spec.rb
+++ b/spec/app_spec.rb
@@ -32,10 +32,13 @@ describe PpwmMatcher::App do
       it 'if the user exists, says Hello github_login' do
         login_as github_user
 
-        PpwmMatcher::User.update_or_create('foo@example.com', github_user)
-        get "/profile/#{github_user.login}"
+        user = PpwmMatcher::User.update_or_create('foo@example.com', github_user)
+        get "/profile/#{user.github_login}"
 
-        expect(last_response.body).to include("Hello #{github_user.login}")
+        [:github_login, :name, :email, :gravatar_id].each do |profile_attribute|
+          expect(last_response.body).to include(user.public_send(profile_attribute))
+        end
+
       end
       it 'if user does not exists,says No such user' do
         login_as github_user


### PR DESCRIPTION
As @bf4 and @rich-ware :

To surface user profile behind github authentication per https://github.com/avdi/ppwm/issues/8

Thoughts of the feature 'finding your pair'
# Finding Your Pair
## User profile page
- [ ] Show user profile info (wip)
## Registered User features
- [ ] 0) User has account on site, does not interfer with the 'matcher'
- [ ] 1) has pairing interests
  1. [] technologies
  2. [] repos
  3. [] techniques
-  [ ] 2) site can contact user over email
  1. [ ] email address
- [ ] 3) site can display contact info
- [ ] 4) site needs scheduling ability
## User profile information
- [x] email address
- [x] name / github user
- [ ] how to contact
- [ ] pairing interests
- [ ] location
- [x] gravatar
- [ ] time zone
- [ ] twitter
- [ ] about me
