### PR TITLE
prevent duplicate user from being added in Code#assign_user

### DIFF
--- a/lib/ppwm_matcher/models/code.rb
+++ b/lib/ppwm_matcher/models/code.rb
@@ -18,7 +18,8 @@ module PpwmMatcher
     end
 
     def assign_user(user)
-      users << user
+      users << user 
+			users.uniq!
       notify_observers :users_assigned, users
     end
 

--- a/spec/models/code_spec.rb
+++ b/spec/models/code_spec.rb
@@ -80,6 +80,11 @@ describe PpwmMatcher::Code do
         observer.should_receive(:users_assigned).with([user1, user2])
         code.assign_user(user2)
       end
+
+      it "should not pass duplicate user to observer" do
+        observer.should_receive(:users_assigned).with([user1])
+        code.assign_user(user1)
+      end
     end
   end
 


### PR DESCRIPTION
After receiving a match code at LSRC, I noticed that if I entered in my code a second time, the page would still tell me that my pair hadn't signed in yet.  However, I received an email saying that I was matched to myself.  

I think this is because my github user was being passed to the mail observer in Code#assign_user twice.  The quickest fix I could think of was calling users.uniq!, but would love any feedback if there's a better way.  Thanks!
